### PR TITLE
Fix color conversion

### DIFF
--- a/lua/conv/init.lua
+++ b/lua/conv/init.lua
@@ -431,7 +431,7 @@ local function convertColor(param)
     vim.api.nvim_buf_set_lines(bufHandle, 0, 1, false, {'  '})
     --vim.api.nvim_buf_add_highlight(bufHandle, -1, 'ErrorMsg', 0, 0, 2)
     local ns_id = vim.api.nvim_get_namespaces()[NS_NAME]
-    vim.api.nvim__set_hl_ns(ns_id)
+    vim.api.nvim_set_hl_ns(ns_id)
     vim.api.nvim_set_hl(ns_id, HL_NAME, {background=hexColor})
     vim.api.nvim_echo({{outputStr .. ' ', ''}, {'  ', HL_NAME}}, false, {})
 end


### PR DESCRIPTION
When trying to use `ConvColor` I got this error:
```nvim-conv/lua/conv/init.lua:434: attempt to call field 'nvim__set_hl_ns' (a nil value)```

I'm not really sure how this ever worked but after using the correct function name (`nvim__set_hl_ns` -> `nvim_set_hl_ns`) everything seems to work as expected.